### PR TITLE
fixes threads_per_chain in StanSample.jl

### DIFF
--- a/Torsten-Runs/hcv.jl
+++ b/Torsten-Runs/hcv.jl
@@ -15,10 +15,13 @@ include(joinpath(@__DIR__, "hcv_data.jl"))
 
 rc = stan_sample(
     m;
-    use_cpp_chains=true,
     data=stan_data,
     init=stan_init,
     num_chains=4,
+    use_cpp_chains=true,
+    check_num_chains=false,
+    num_cpp_chains=4,
+    num_threads=Threads.nthreads(),
     num_samples=1_000,
     num_warmups=1_000,
     delta=0.8

--- a/Torsten-Runs/pk2cpt.jl
+++ b/Torsten-Runs/pk2cpt.jl
@@ -13,10 +13,13 @@ include(joinpath(@__DIR__, "pk2cpt_data.jl"))
 
 rc = stan_sample(
     m;
-    use_cpp_chains=true,
     data=stan_data,
     init=stan_init,
     num_chains=4,
+    use_cpp_chains=true,
+    check_num_chains=false,
+    num_cpp_chains=4,
+    num_threads=Threads.nthreads(),
     num_samples=1_000,
     num_warmups=1_000,
     delta=0.8

--- a/Torsten-Runs/poppk2cpt-reduce_sum_ode.jl.jl
+++ b/Torsten-Runs/poppk2cpt-reduce_sum_ode.jl.jl
@@ -16,10 +16,13 @@ include(joinpath(@__DIR__, "poppk2cpt-reduce_sum_ode_data.jl"))
 
 rc = stan_sample(
     m;
-    use_cpp_chains=true,
     data=stan_data,
     init=stan_init,
     num_chains=4,
+    use_cpp_chains=true,
+    check_num_chains=false,
+    num_cpp_chains=4,
+    num_threads=Threads.nthreads(),
     num_samples=1_000,
     num_warmups=1_000,
     delta=0.8


### PR DESCRIPTION
Somehow using "Julia" threads instead of "C++ threads" does not uses all available cores.

These changes in the `pk2cpt`, `poppk2cpt-reduce_sum_ode` and `hcv` models triggers `CmdStan` being called from `StanSample.jl` to use all threads!
![image](https://user-images.githubusercontent.com/43353831/192281758-69de9b52-b5d7-497a-942f-1550e55bc8de.png)
